### PR TITLE
fix: refactor flags & package install option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-filecoin-app",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A CLI to create a Filecoin-based application",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Fixed double usage of storage provider flags using the --provider flag, and make package installation optional using the --skip-install flag.

Usage: 
```
npx create-filecoin-app my-app --provider storacha --skip-install
```

This creates a repo (my-app) using storacha as the provider, and skips package installation. 
By default, packages would be installed, so the flag is optional.